### PR TITLE
Add Functionality to Ignore Nearly expired RIs with Specified Tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   dummy_end_time:
     description: "Dummy end time for testing"
     required: false
+  ignore_tags:
+    description: "Semicolon-separated list of tags to ignore. eg 'key1=value1;key2=value2'"
+    required: false
   version:
     description: "Version of riex to use"
     default: "0.0.5"
@@ -29,6 +32,9 @@ runs:
         days_left=${{ inputs.days_left }}
         if [[ "${{ inputs.dummy_end_time }}" != "" ]]; then
           opts="--dummy-output --dummy-end-time ${{ inputs.dummy_end_time }}"
+        fi
+        if [[ "${{ inputs.ignore_tags }}" != "" ]]; then
+          opts="$opts --ignore-tags ${{ inputs.ignore_tags }}"
         fi
         output=$(riex $days_left --format markdown $opts)
 

--- a/cli.go
+++ b/cli.go
@@ -8,12 +8,13 @@ import (
 )
 
 type Option struct {
-	Active       bool      `help:"Show active reserved instances."`
-	Expired      int       `help:"Show reserved instances expired in the last specified days."`
-	Days         int       `arg:"" help:"Show reserved instances that will be expired within specified days."`
-	Format       string    `enum:"json,markdown,tsv" help:"Output format.(json, markdown, tsv)" default:"json"`
-	DummyOutput  bool      `help:"Dummy output for testing."`
-	DummyEndTime time.Time `help:"Endtime for testing. works only with --dummy-output."`
+	Active         bool              `help:"Show active reserved instances."`
+	Expired        int               `help:"Show reserved instances expired in the last specified days."`
+	Days           int               `arg:"" help:"Show reserved instances that will be expired within specified days."`
+	Format         string            `enum:"json,markdown,tsv" help:"Output format.(json, markdown, tsv)" default:"json"`
+	DummyOutput    bool              `help:"Dummy output for testing."`
+	DummyEndTime   time.Time         `help:"Endtime for testing. works only with --dummy-output."`
+	RecognizedTags map[string]string `help:"Resource tag for recognized RI." default:"riex=recognized"`
 }
 
 func RunCLI(ctx context.Context, args []string) error {

--- a/cli.go
+++ b/cli.go
@@ -9,6 +9,7 @@ import (
 
 type Option struct {
 	Active         bool              `help:"Show active reserved instances."`
+	Recognized     bool              `help:"Show recognized reserved instances."`
 	Expired        int               `help:"Show reserved instances expired in the last specified days."`
 	Days           int               `arg:"" help:"Show reserved instances that will be expired within specified days."`
 	Format         string            `enum:"json,markdown,tsv" help:"Output format.(json, markdown, tsv)" default:"json"`

--- a/cli.go
+++ b/cli.go
@@ -8,14 +8,14 @@ import (
 )
 
 type Option struct {
-	Active         bool              `help:"Show active reserved instances."`
-	Recognized     bool              `help:"Show recognized reserved instances."`
-	Expired        int               `help:"Show reserved instances expired in the last specified days."`
-	Days           int               `arg:"" help:"Show reserved instances that will be expired within specified days."`
-	Format         string            `enum:"json,markdown,tsv" help:"Output format.(json, markdown, tsv)" default:"json"`
-	DummyOutput    bool              `help:"Dummy output for testing."`
-	DummyEndTime   time.Time         `help:"Endtime for testing. works only with --dummy-output."`
-	RecognizedTags map[string]string `help:"Resource tag for recognized RI." default:"riex=recognized"`
+	Active       bool              `help:"Show active reserved instances."`
+	Ignored      bool              `help:"Show ignored reserved instances."`
+	Expired      int               `help:"Show reserved instances expired in the last specified days."`
+	Days         int               `arg:"" help:"Show reserved instances that will be expired within specified days."`
+	Format       string            `enum:"json,markdown,tsv" help:"Output format.(json, markdown, tsv)" default:"json"`
+	DummyOutput  bool              `help:"Dummy output for testing."`
+	DummyEndTime time.Time         `help:"Endtime for testing. works only with --dummy-output."`
+	IgnoreTags   map[string]string `help:"Resource tag for ignore RI."`
 }
 
 func RunCLI(ctx context.Context, args []string) error {

--- a/cli.go
+++ b/cli.go
@@ -9,7 +9,6 @@ import (
 
 type Option struct {
 	Active       bool              `help:"Show active reserved instances."`
-	Ignored      bool              `help:"Show ignored reserved instances."`
 	Expired      int               `help:"Show reserved instances expired in the last specified days."`
 	Days         int               `arg:"" help:"Show reserved instances that will be expired within specified days."`
 	Format       string            `enum:"json,markdown,tsv" help:"Output format.(json, markdown, tsv)" default:"json"`

--- a/ec2.go
+++ b/ec2.go
@@ -14,6 +14,10 @@ func (app *Riex) detectEC2(ctx context.Context) (*ReservedInstances, error) {
 		return nil, err
 	}
 	for _, ins := range out.ReservedInstances {
+		tags := make(map[string]string, len(ins.Tags))
+		for _, tag := range ins.Tags {
+			tags[*tag.Key] = *tag.Value
+		}
 		ri := ReservedInstance{
 			Service:      "EC2",
 			InstanceType: string(ins.InstanceType),
@@ -23,6 +27,7 @@ func (app *Riex) detectEC2(ctx context.Context) (*ReservedInstances, error) {
 			StartTime:    aws.ToTime(ins.Start),
 			EndTime:      aws.ToTime(ins.End),
 			State:        string(ins.State),
+			Tags:         tags,
 		}
 		if app.isPrintable(ri) {
 			ris = append(ris, ri)

--- a/opensearch.go
+++ b/opensearch.go
@@ -28,6 +28,7 @@ func (app *Riex) detectOpensearch(ctx context.Context) (*ReservedInstances, erro
 				StartTime:    aws.ToTime(node.StartTime),
 				EndTime:      node.StartTime.Add(time.Second * time.Duration(node.Duration)),
 				State:        aws.ToString(node.State),
+				Tags:         make(map[string]string), // opeansearch reserved instance does not support tags
 			}
 			if app.isPrintable(ri) {
 				ris = append(ris, ri)

--- a/redshift.go
+++ b/redshift.go
@@ -28,6 +28,7 @@ func (app *Riex) detectRedshift(ctx context.Context) (*ReservedInstances, error)
 				StartTime:    aws.ToTime(node.StartTime),
 				EndTime:      node.StartTime.Add(time.Second * time.Duration(node.Duration)),
 				State:        aws.ToString(node.State),
+				Tags:         make(map[string]string), // redshift reserved instance does not support tags
 			}
 			if app.isPrintable(ri) {
 				ris = append(ris, ri)

--- a/riex.go
+++ b/riex.go
@@ -26,13 +26,12 @@ import (
 var Version string
 
 type Riex struct {
-	config         aws.Config
-	ec2            *ec2.Client
-	elasticache    *elasticache.Client
-	rds            *rds.Client
-	redshift       *redshift.Client
-	opensearch     *opensearch.Client
-	recognizedTags map[string]string
+	config      aws.Config
+	ec2         *ec2.Client
+	elasticache *elasticache.Client
+	rds         *rds.Client
+	redshift    *redshift.Client
+	opensearch  *opensearch.Client
 
 	option    *Option
 	startTime time.Time
@@ -48,16 +47,15 @@ func New(ctx context.Context, opt *Option) (*Riex, error) {
 
 	now := time.Now()
 	app := &Riex{
-		config:         awscfg,
-		ec2:            ec2.NewFromConfig(awscfg),
-		elasticache:    elasticache.NewFromConfig(awscfg),
-		rds:            rds.NewFromConfig(awscfg),
-		redshift:       redshift.NewFromConfig(awscfg),
-		opensearch:     opensearch.NewFromConfig(awscfg),
-		option:         opt,
-		startTime:      now.Add(time.Duration(-opt.Expired) * 24 * time.Hour),
-		endTime:        now.Add(time.Duration(opt.Days) * 24 * time.Hour),
-		recognizedTags: opt.RecognizedTags,
+		config:      awscfg,
+		ec2:         ec2.NewFromConfig(awscfg),
+		elasticache: elasticache.NewFromConfig(awscfg),
+		rds:         rds.NewFromConfig(awscfg),
+		redshift:    redshift.NewFromConfig(awscfg),
+		opensearch:  opensearch.NewFromConfig(awscfg),
+		option:      opt,
+		startTime:   now.Add(time.Duration(-opt.Expired) * 24 * time.Hour),
+		endTime:     now.Add(time.Duration(opt.Days) * 24 * time.Hour),
 	}
 	return app, nil
 }
@@ -191,8 +189,8 @@ func (app *Riex) PrintTSV(ris ReservedInstances, w io.Writer) error {
 }
 
 func (app *Riex) isPrintable(ri ReservedInstance) bool {
-	if len(app.recognizedTags) > 0 {
-		for key, recognizedValue := range app.recognizedTags {
+	if !app.option.Recognized && len(app.option.RecognizedTags) > 0 {
+		for key, recognizedValue := range app.option.RecognizedTags {
 			if v, ok := ri.Tags[key]; ok && recognizedValue == v {
 				return false
 			}

--- a/riex.go
+++ b/riex.go
@@ -189,7 +189,7 @@ func (app *Riex) PrintTSV(ris ReservedInstances, w io.Writer) error {
 }
 
 func (app *Riex) isPrintable(ri ReservedInstance) bool {
-	if !app.option.Ignored && len(app.option.IgnoreTags) > 0 {
+	if len(app.option.IgnoreTags) > 0 {
 		for key, value := range app.option.IgnoreTags {
 			if tag, ok := ri.Tags[key]; ok && value == tag {
 				return false

--- a/riex.go
+++ b/riex.go
@@ -189,9 +189,9 @@ func (app *Riex) PrintTSV(ris ReservedInstances, w io.Writer) error {
 }
 
 func (app *Riex) isPrintable(ri ReservedInstance) bool {
-	if !app.option.Recognized && len(app.option.RecognizedTags) > 0 {
-		for key, recognizedValue := range app.option.RecognizedTags {
-			if v, ok := ri.Tags[key]; ok && recognizedValue == v {
+	if !app.option.Ignored && len(app.option.IgnoreTags) > 0 {
+		for key, value := range app.option.IgnoreTags {
+			if tag, ok := ri.Tags[key]; ok && value == tag {
 				return false
 			}
 		}


### PR DESCRIPTION
This pull request introduces a new feature to exclude expired Reserved Instances (RIs) when specific tags are associated with them, preventing them from being displayed as expired. The motivation behind this feature is to enhance the efficiency of frequent riex executions by excluding RIs that are nearing their expiration date but are already acknowledged.

To achieve this, the functionality leverages the capability of tagging EC2, Elasticache, and RDS instances with Reserved Instances. When a specified tag is present, the associated RIs are considered acknowledged and will be ignored, ensuring they are not included in the display results.

Please review and provide feedback on this pull request. Thank you!

## Behavier

For example, RDS RI 

<img width="649" alt="スクリーンショット 2023-06-13 10 40 20" src="https://github.com/fujiwara/riex/assets/24449460/9c11f110-fd42-439a-8ec1-f3624eb90476">

in default:

```
$ go run cmd/riex/main.go 90 --format markdown
| service | name | description | instance_type | count | start_time | end_time | state |
| --- | --- | --- | --- | --- | --- | --- | --- |
| RDS | example-hoge-hoge | aurora-mysql | db.t4g.medium | 1 | 2022-07-01T00:00:00Z | 2023-07-01T00:00:00Z | active |

```

if add --ignore-tags key1=value1;key2=value2

```
$ go run cmd/riex/main.go 90 --ignore-tags riex=recognized --format markdown
```

Currently, it is assumed that the recognized tags are attached manually.